### PR TITLE
Update course life-cycle flag to Alpha

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,14 +14,14 @@ carpentry: 'incubator'
 title: 'Performance Profiling & Optimisation (Python)'
 
 # Date the lesson was created (YYYY-MM-DD, this is empty by default)
-created: ~ # FIXME
+created: 2024-02-01~ # FIXME
 
 # Comma-separated list of keywords for the lesson
 keywords: 'python, profiling, optimisation, data structures, algorithms'
 
 # Life cycle stage of the lesson
 # possible values: pre-alpha, alpha, beta, stable
-life_cycle: 'pre-alpha'
+life_cycle: 'alpha'
 
 # License of the lesson
 license: 'CC-BY 4.0'


### PR DESCRIPTION
Carpentries standards states a course is Alpha when it has been delivered atleast once by the author.

It must be delivered by someone, other than the author to reach Beta.