### PR TITLE
Improve NumPy page

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -68,7 +68,7 @@ episodes:
 - optimisation-using-python.md
 - optimisation-data-structures-algorithms.md
 - long-break1.md
-- optimisation-minimise-python.md
+- optimisation-numpy.md
 - optimisation-use-latest.md
 - optimisation-memory.md
 - optimisation-conclusion.md

--- a/episodes/optimisation-numpy.md
+++ b/episodes/optimisation-numpy.md
@@ -255,6 +255,8 @@ Similar to the demos above, we can often gain significant performance boosts by 
 
 ::::::::::::::::::::::::::::::::::::: challenge
 
+### Challenge: Which Libraries Are You Using Already?
+
 Take a look at the [list of libraries on the NumPy website](https://numpy.org/#:~:text=ECOSYSTEM). Are you using any of them already?
 
 If you've brought a project you want to work on: Are there areas of the project where you might benefit from adapting one of these libraries instead of writing your own code from scratch?

--- a/episodes/optimisation-numpy.md
+++ b/episodes/optimisation-numpy.md
@@ -1,5 +1,5 @@
 ---
-title: "Using Scientific Python Libraries (NumPy, Pandas and more)"
+title: "Using Scientific Python Packages (NumPy, Pandas and more)"
 teaching: 30
 exercises: 0
 ---
@@ -193,7 +193,7 @@ Most modern processors are able to apply one instruction across multiple variabl
 If we were to use a regular `for` loop, the time to perform this operation would increase with the length of the array.
 However, using NumPy broadcasting we can apply the addition to 1, 10 or 100 elements, all in the same amount of time!
 
-Earlier in this episode it was demonstrated that using core Python methods over a list will outperform a loop, performing the same calculation faster. The below example takes this a step further by demonstrating the calculation of a dot product.
+Earlier it was demonstrated that using core Python methods over a list will outperform a loop, performing the same calculation faster. The below example takes this a step further by demonstrating the calculation of a dot product.
 
 <!-- Inspired by High Performance Python Chapter 6 example 
 Added Python sum array, skipped a couple of others--> 
@@ -268,7 +268,7 @@ These libraries could be specific to your area of research; but they could also 
 :::::::::::::::::::::::::::::::::::::::::::::::
 
 
-Which libraries you may use will depend on your research domain; here, we'll show two examples from our own experience.
+Which libraries you may use will depend on your research domain; here, we'll show an example from bioinformatics.
 
 ### Example: Image Analysis with Shapely
 
@@ -304,7 +304,7 @@ points_per_polygon = {}
 for polygon_idx in range(n_polygons):
     current_polygon = polygons.iloc[polygon_idx,:]["geometry"]
 
-    # vectorised: apply `contains` to an array of points at once
+    # vectorised: apply `contains` to an array of points, rather than an individual point
     points_in_polygon_idx = current_polygon.contains(points_array)
     points_in_polygon = point_names_array[points_in_polygon_idx]
     

--- a/episodes/optimisation-numpy.md
+++ b/episodes/optimisation-numpy.md
@@ -180,7 +180,6 @@ array([  1.        ,   2.71828183,   7.3890561 ,  20.08553692,
 However, broadcasting is not just a nicer way to write mathematical expressions—it can also give a significant performance boost:
 Most modern processors are able to apply one instruction across multiple variables simultaneously, instead of sequentially. (In computer science, this is also referred to as "vectorisation".) The manner by which NumPy stores data in arrays enables it to vectorise mathematical operations that are broadcast across arrays.
 
-<!-- Analogy: If you're baking cookies, the oven (CPU register) is big enough to operate on multiple cookies (numbers) simultaneously. So whether you bake 1 cookie or 10, it'll take exactly the same amount of time. -->
 
 ```sh
 > python -m timeit -s "import numpy; ar = numpy.arange(1)" "ar + 10"
@@ -192,6 +191,18 @@ Most modern processors are able to apply one instruction across multiple variabl
 ```
 If we were to use a regular `for` loop, the time to perform this operation would increase with the length of the array.
 However, using NumPy broadcasting we can apply the addition to 1, 10 or 100 elements, all in the same amount of time!
+
+::::::::::::::::::::::::::::::::::::: instructor
+
+A simple analogy:
+
+If you're baking cookies, the oven (CPU register) is big enough to operate on multiple cookies (numbers) simultaneously. So whether you bake 1 cookie or 10, it'll take exactly the same amount of time.
+However, this requires that the cookies are neatly arranged on a baking tray (in a contiguous chunk of memory).
+
+Basic ints/floats in NumPy arrays are arranged like that, so this works great.
+In contrast, numbers in a Python list [are spread across memory in a fairly complex arrangement](https://jakevdp.github.io/blog/2014/05/09/why-python-is-slow/#3.-Python's-object-model-can-lead-to-inefficient-memory-access), so cannot benefit from this unless you convert them to a NumPy array first.
+
+::::::::::::::::::::::::::::::::::::::::::::::::
 
 Earlier it was demonstrated that using core Python methods over a list will outperform a loop, performing the same calculation faster. The below example takes this a step further by demonstrating the calculation of a dot product.
 
@@ -324,7 +335,6 @@ To vectorise this efficiently, the logic of the code had to be changed slightly:
 ::::::::::::::::::::::::::::::::::::: instructor
 
 The following code snippet demonstrates how this works for a simplified example.
-If you want to run this as a live demo, you need to `pip install shapely` first.
 
 ```Python
 >>> from shapely import Point, Polygon

--- a/episodes/optimisation-numpy.md
+++ b/episodes/optimisation-numpy.md
@@ -247,44 +247,6 @@ However, HPC systems should be primed to take advantage, so try increasing the n
 
 :::::::::::::::::::::::::::::::::::::
 
-### `vectorize()`
-
-Python's `map()` was introduced earlier, for applying a function to all elements within a list.
-NumPy provides `vectorize()` an equivalent for operating over its arrays.
-
-This doesn't actually make use of processor-level vectorisation, from the [documentation](https://numpy.org/doc/stable/reference/generated/numpy.vectorize.html):
-
-> The `vectorize` function is provided primarily for convenience, not for performance. The implementation is essentially a for loop.
-
-The below example demonstrates how the performance of `vectorize()` is only marginally faster than `map()`.
-
-```python
-N = 100000  # Number of elements in list/array
-
-def genArray():
-    return numpy.arange(N)
-
-def plus_one(x):
-    return x + 1
-    
-def python_map():
-    ar = genArray()
-    return list(map(plus_one, ar))
-
-def numpy_vectorize():
-    ar = genArray()
-    return numpy.vectorize(plus_one)(ar)
-
-repeats = 1000
-gentime = timeit(genArray, number=repeats)
-print(f"python_map: {timeit(python_map, number=repeats)-gentime:.2f}ms")
-print(f"numpy_vectorize: {timeit(numpy_vectorize, number=repeats)-gentime:.2f}ms")
-```
-
-```output
-python_map: 7.94ms
-numpy_vectorize: 7.80ms
-```
 
 ## Other libraries that use NumPy
 
@@ -379,7 +341,7 @@ Pandas' methods by default operate on columns. Each column or series can be thou
 
 Following the theme of this episode, iterating over the rows of a data frame using a `for` loop is not advised. The pythonic iteration will be slower than other approaches.
 
-Pandas allows it's own methods to be applied to rows in many cases by passing `axis=1`, where available these functions should be preferred over manual loops. Where you can't find a suitable method, `apply()` can be used, which is similar to `map()`/`vectorize()`, to apply your own function to rows.
+Pandas allows it's own methods to be applied to rows in many cases by passing `axis=1`, where available these functions should be preferred over manual loops. Where you can't find a suitable method, `apply()` can be used, which is similar to `map()`, to apply your own function to rows.
 
 ```python
 from timeit import timeit

--- a/episodes/optimisation-numpy.md
+++ b/episodes/optimisation-numpy.md
@@ -124,9 +124,68 @@ There is however a trade-off, using `numpy.random.choice()` can be clearer to so
 
 :::::::::::::::::::::::::::::::::::::::::::::
 
-### Vectorisation
+### Array broadcasting
 
-The manner by which NumPy stores data in arrays enables it's functions to utilise vectorisation, whereby the processor executes one instruction across multiple variables simultaneously, for every mathematical operation between arrays.
+NumPy arrays support “[broadcasting](https://numpy.org/doc/stable/user/basics.broadcasting.html)” many mathematical operations or functions.
+This is a shorthand notation, where the operation/function is applied element-wise without having to loop over the array explicitly:
+
+```Python
+>>> import numpy as np
+>>> ar = np.arange(6)
+>>> ar
+array([0, 1, 2, 3, 4, 5])
+>>> ar + 10
+array([10, 11, 12, 13, 14, 15])
+>>> ar * 2
+array([ 0,  2,  4,  6,  8, 10])
+>>> ar**2
+array([ 0,  1,  4,  9, 16, 25])
+>>> np.exp(ar)
+array([  1.        ,   2.71828183,   7.3890561 ,  20.08553692,
+        54.59815003, 148.4131591 ])
+```
+
+::::::::::::::::::::::::::::::::::::: callout
+
+If you try the same with Python lists, it will usually fail with an error or give an unexpected result:
+
+```Python
+>>> ls = list(range(6))
+>>> ls + 10
+Traceback (most recent call last):
+  File "<python-input-8>", line 1, in <module>
+    ls + 10
+    ~~~^~~~
+TypeError: can only concatenate list (not "int") to list
+>>> ls * 2
+[0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5]
+>>> ls ** 2
+Traceback (most recent call last):
+  File "<python-input-10>", line 1, in <module>
+    ls ** 2
+    ~~~^^~~
+TypeError: unsupported operand type(s) for ** or pow(): 'list' and 'int'
+>>> np.exp(ls)  # works but is slower, because NumPy converts the list into an array first
+array([  1.        ,   2.71828183,   7.3890561 ,  20.08553692,
+        54.59815003, 148.4131591 ])
+```
+:::::::::::::::::::::::::::::::::::::::::::::
+
+However, broadcasting is not just a nicer way to write mathematical expressions—it can also give a significant performance boost:
+Most modern processors are able to apply one instruction across multiple variables simultaneously, instead of sequentially. (In computer science, this is also referred to as “vectorisation”.) The manner by which NumPy stores data in arrays enables it to vectorise mathematical operations that are broadcast across arrays.
+
+<!-- Analogy: If you’re baking cookies, the oven (CPU register) is big enough to operate on multiple cookies (numbers) simultaneously. So whether you bake 1 cookie or 10, it’ll take exactly the same amount of time. -->
+
+```sh
+> python -m timeit -s "import numpy; ar = numpy.arange(1)" "ar + 10"
+1000000 loops, best of 5: 359 nsec per loop
+> python -m timeit -s "import numpy; ar = numpy.arange(10)" "ar + 10"
+1000000 loops, best of 5: 362 nsec per loop
+> python -m timeit -s "import numpy; ar = numpy.arange(100)" "ar + 10"
+1000000 loops, best of 5: 364 nsec per loop
+```
+If we were to use a regular `for` loop, the time to perform this operation would increase with the length of the array.
+However, using NumPy broadcasting we can apply the addition to 1, 10 or 100 elements, all in the same amount of time!
 
 Earlier in this episode it was demonstrated that using core Python methods over a list, will outperform a loop performing the same calculation faster. The below example takes this a step further by demonstrating the calculation of dot product.
 

--- a/episodes/optimisation-numpy.md
+++ b/episodes/optimisation-numpy.md
@@ -1,5 +1,5 @@
 ---
-title: "Understanding Python (NumPy/Pandas)"
+title: "Using Scientific Python Libraries (NumPy, Pandas and more)"
 teaching: 30
 exercises: 0
 ---

--- a/episodes/optimisation-numpy.md
+++ b/episodes/optimisation-numpy.md
@@ -18,7 +18,7 @@ exercises: 0
 
 ::::::::::::::::::::::::::::::::::::::::::::::::
 
-Earlier, we saw that builtin functions in Python, like `sum()`, are often faster than manually looping over a list. This is because those high-level functions are able to do most of the work in the C backend
+Earlier, we saw that built-in Python functions, like `sum()`, are often faster than manually looping over a list. This is because those high-level functions are able to do most of the work in the C backend.
 
 Packages like NumPy and Pandas work similarly: They have been written in compiled languages to expose this performance across a wide range of scientific workloads.
 
@@ -28,7 +28,7 @@ Packages like NumPy and Pandas work similarly: They have been written in compile
 
 [NumPy](https://numpy.org/) is a commonly used package for scientific computing, which provides a wide variety of methods.
 
-It adds restriction via it's own [basic numeric types](https://numpy.org/doc/stable/user/basics.types.html), and static arrays to enable even greater performance than that of core Python. However if these restrictions are ignored, the performance can become significantly worse.
+It adds restriction via its own [basic numeric types](https://numpy.org/doc/stable/user/basics.types.html) and static arrays to enable even greater performance than that of core Python. However if these restrictions are ignored, the performance can become significantly worse.
 
 <!--
 TODO: It might be nice to use the figure from https://jakevdp.github.io/blog/2014/05/09/why-python-is-slow/#3.-Python's-object-model-can-lead-to-inefficient-memory-access here for illustration?
@@ -36,9 +36,9 @@ TODO: It might be nice to use the figure from https://jakevdp.github.io/blog/201
 ![Illustration of a NumPy array and a Python list.](episodes/fig/numpyarray_vs_pylist.png){alt="A diagram illustrating the difference between a NumPy array and a Python list. The NumPy array is a raw block of memory containing numerical values. A Python list contains a header with metadata and multiple items, each of which is a reference to another Python object with its own header and value."}
 -->
 
-### NumPy arrays and Python lists live in two separate worlds
+### NumPy Arrays and Python Lists Live in Two Separate Worlds
 
-NumPy's arrays (not to be confused with the core Python `array` package) are static arrays. Unlike core Python's lists, they do not dynamically resize. Therefore if you wish to append to a NumPy array, you must call `resize()` first. If you treat this like `append()` for a Python list, resizing for each individual append you will be performing significantly more copies and memory allocations than a Python list.
+NumPy's arrays (not to be confused with the core Python `array` package) are static arrays. Unlike core Python's lists, they do not dynamically resize. Therefore if you wish to append to a NumPy array, you must call `resize()` first. If you treat this like `append()` for a Python list, resizing for each individual append, you will be performing significantly more copies and memory allocations than a Python list.
 
 The below example sees lists and arrays constructed from `range(100000)`.
 
@@ -64,7 +64,7 @@ print(f"list_append: {timeit(list_append, number=repeats):.2f}ms")
 print(f"array_resize: {timeit(array_resize, number=repeats):.2f}ms")
 ```
 
-For Python lists, we’ve seen earlier that list comprehensions are more efficient, so we prefer to avoid using a large number of `append` operations if possible. Similarly, we should try to avoid resizing NumPy arrays, where the overhead is even higher (5.2x slower than a list, probably 10x slower than list comprehension).
+For Python lists, we've seen earlier that list comprehensions are more efficient, so we prefer to avoid using a large number of `append` operations if possible. Similarly, we should try to avoid resizing NumPy arrays, where the overhead is even higher (5.2x slower than a list, probably 10x slower than list comprehension).
 
 ```output
 list_append: 3.50ms
@@ -130,9 +130,9 @@ There is however a trade-off, using `numpy.random.choice()` can be clearer to so
 
 :::::::::::::::::::::::::::::::::::::::::::::
 
-### Array broadcasting
+### Array Broadcasting
 
-NumPy arrays support “[broadcasting](https://numpy.org/doc/stable/user/basics.broadcasting.html)” many mathematical operations or functions.
+NumPy arrays support "[broadcasting](https://numpy.org/doc/stable/user/basics.broadcasting.html)" many mathematical operations or functions.
 This is a shorthand notation, where the operation/function is applied element-wise without having to loop over the array explicitly:
 
 ```Python
@@ -178,9 +178,9 @@ array([  1.        ,   2.71828183,   7.3890561 ,  20.08553692,
 :::::::::::::::::::::::::::::::::::::::::::::
 
 However, broadcasting is not just a nicer way to write mathematical expressions—it can also give a significant performance boost:
-Most modern processors are able to apply one instruction across multiple variables simultaneously, instead of sequentially. (In computer science, this is also referred to as “vectorisation”.) The manner by which NumPy stores data in arrays enables it to vectorise mathematical operations that are broadcast across arrays.
+Most modern processors are able to apply one instruction across multiple variables simultaneously, instead of sequentially. (In computer science, this is also referred to as "vectorisation".) The manner by which NumPy stores data in arrays enables it to vectorise mathematical operations that are broadcast across arrays.
 
-<!-- Analogy: If you’re baking cookies, the oven (CPU register) is big enough to operate on multiple cookies (numbers) simultaneously. So whether you bake 1 cookie or 10, it’ll take exactly the same amount of time. -->
+<!-- Analogy: If you're baking cookies, the oven (CPU register) is big enough to operate on multiple cookies (numbers) simultaneously. So whether you bake 1 cookie or 10, it'll take exactly the same amount of time. -->
 
 ```sh
 > python -m timeit -s "import numpy; ar = numpy.arange(1)" "ar + 10"
@@ -193,14 +193,14 @@ Most modern processors are able to apply one instruction across multiple variabl
 If we were to use a regular `for` loop, the time to perform this operation would increase with the length of the array.
 However, using NumPy broadcasting we can apply the addition to 1, 10 or 100 elements, all in the same amount of time!
 
-Earlier in this episode it was demonstrated that using core Python methods over a list, will outperform a loop performing the same calculation faster. The below example takes this a step further by demonstrating the calculation of dot product.
+Earlier in this episode it was demonstrated that using core Python methods over a list will outperform a loop, performing the same calculation faster. The below example takes this a step further by demonstrating the calculation of a dot product.
 
 <!-- Inspired by High Performance Python Chapter 6 example 
 Added Python sum array, skipped a couple of others--> 
 ```python
 from timeit import timeit
 
-N = 1_000_000  # Number of elements in list
+N = 1000000  # Number of elements in list
 
 gen_list = f"ls = list(range({N}))"
 gen_array = f"import numpy; ar = numpy.arange({N}, dtype=numpy.int64)"
@@ -218,7 +218,7 @@ print(f"numpy_dot_array: {timeit(np_dot_ar, setup=gen_array, number=repeats):.2f
 ```
 
 * `python_sum_list` uses list comprehension to perform the multiplication, followed by the Python core `sum()`. This comes out at 46.93ms
-* `python_sum_array` instead directly multiplies the two arrays, taking advantage of NumPy's vectorisation. But uses the core Python `sum()`, this comes in slightly faster at 33.26ms.
+* `python_sum_array` instead directly multiplies the two arrays (taking advantage of NumPy's vectorisation) but uses the core Python `sum()`, this comes in slightly faster at 33.26ms.
 * `numpy_sum_array` again takes advantage of NumPy's vectorisation for the multiplication, and additionally uses NumPy's `sum()` implementation. These two rounds of vectorisation provide a much faster 1.44ms completion.
 * `numpy_dot_array` instead uses NumPy's `dot()` to calculate the dot product in a single operation. This comes out the fastest at 0.29ms, 162x faster than `python_sum_list`. 
 
@@ -248,7 +248,7 @@ However, HPC systems should be primed to take advantage, so try increasing the n
 :::::::::::::::::::::::::::::::::::::
 
 
-## Other libraries that use NumPy
+## Other Libraries That Use NumPy
 
 Across the scientific Python software ecosystem, [many domain-specific packages](https://numpy.org/#:~:text=ECOSYSTEM) are built on top of NumPy arrays.
 Similar to the demos above, we can often gain significant performance boosts by using these libraries well.
@@ -257,7 +257,7 @@ Similar to the demos above, we can often gain significant performance boosts by 
 
 Take a look at the [list of libraries on the NumPy website](https://numpy.org/#:~:text=ECOSYSTEM). Are you using any of them already?
 
-If you’ve brought a project you want to work on: Are there areas of the project where you might benefit from adapting one of these libraries instead of writing your own code from scratch?
+If you've brought a project you want to work on: Are there areas of the project where you might benefit from adapting one of these libraries instead of writing your own code from scratch?
 
 :::::::::::::::::::::::: hint
 
@@ -268,11 +268,11 @@ These libraries could be specific to your area of research; but they could also 
 :::::::::::::::::::::::::::::::::::::::::::::::
 
 
-Which libraries you may use will depend on your research domain; here, we’ll show two examples from our own experience.
+Which libraries you may use will depend on your research domain; here, we'll show two examples from our own experience.
 
-### Example: Image analysis with Shapely
+### Example: Image Analysis with Shapely
 
-A colleague had a large data set of images of cells. She had already reconstructed the locations of cell walls and various points of interest and needed to identify which points were located in each cell.
+A bioinformatics researcher had a large data set of images of cells. She had already reconstructed the locations of cell walls and various points of interest and needed to identify which points were located in each cell.
 To do this, she used the [Shapely](https://github.com/shapely/shapely) geometry library.
 
 ```Python
@@ -345,11 +345,11 @@ And since it’s not a very clean example (mixes np arrays and list comprehensio
 <!--
 ### Example: Interpolating astrophysical spectra with AstroPy
 
-This is from an open-source package I’m working on, so we can look at the actual pull request where I made this change: https://github.com/SNEWS2/snewpy/pull/310
+This is from an open-source package I'm working on, so we can look at the actual pull request where I made this change: https://github.com/SNEWS2/snewpy/pull/310
 
 &rightarrow; See the first table of benchmark results. Note that using a Python `for` loop to calculate the spectrum in 100 different time bins takes 100 times as long as for a single time bin. In the vectorized version, the computing time increases much more slowly.
 
-(Note that energies were already vectorized—that’s another factor of 100 we got “for free”!)
+(Note that energies were already vectorized—that's another factor of 100 we got "for free"!)
 
 Code diff: https://github.com/SNEWS2/snewpy/pull/310/commits/0320b384ff22233818d07913c55c30f5968ae330
  -->
@@ -366,7 +366,7 @@ Pandas' methods by default operate on columns. Each column or series can be thou
 
 Following the theme of this episode, iterating over the rows of a data frame using a `for` loop is not advised. The pythonic iteration will be slower than other approaches.
 
-Pandas allows it's own methods to be applied to rows in many cases by passing `axis=1`, where available these functions should be preferred over manual loops. Where you can't find a suitable method, `apply()` can be used, which is similar to `map()`, to apply your own function to rows.
+Pandas allows its own methods to be applied to rows in many cases by passing `axis=1`, where available these functions should be preferred over manual loops. Where you can't find a suitable method, `apply()` can be used, which is similar to `map()`, to apply your own function to rows.
 
 ```python
 from timeit import timeit
@@ -413,7 +413,7 @@ print(f"for_iterrows: {timeit(for_iterrows, number=repeats)*10-gentime:.2f}ms")
 print(f"pandas_apply: {timeit(pandas_apply, number=repeats)*10-gentime:.2f}ms")
 ```
 
-`apply()` is 3x faster than the two `for` approaches, as it avoids the Python `for` loop.
+`apply()` is 4x faster than the two `for` approaches, as it avoids the Python `for` loop.
 
 
 ```output
@@ -422,7 +422,7 @@ for_iterrows: 1677.14ms
 pandas_apply: 390.49ms
 ```
 
-However, rows don't exist in memory as arrays (columns do!), so `apply()` does not take advantage of NumPys vectorisation. You may be able to go a step further and avoid explicitly operating on rows entirely by passing only the required columns to NumPy.
+However, rows don't exist in memory as arrays (columns do!), so `apply()` does not take advantage of NumPy's vectorisation. You may be able to go a step further and avoid explicitly operating on rows entirely by passing only the required columns to NumPy.
 
 ```python
 def vectorize():
@@ -432,7 +432,7 @@ def vectorize():
 print(f"vectorize: {timeit(vectorize, number=repeats)-gentime:.2f}ms")
 ```
 
-264x faster than `apply()`, 1000x faster than `for` `iterrows()`!
+264x faster than `apply()`, 1000x faster than the two `for` approaches!
 
 ```
 vectorize: 1.48ms
@@ -501,6 +501,6 @@ If you can filter your rows before processing, rather than after, you may signif
 - Python is an interpreted language, this adds an additional overhead at runtime to the execution of Python code. Many core Python and NumPy functions are implemented in faster C/C++, free from this overhead.
 - NumPy can take advantage of vectorisation to process arrays, which can greatly improve performance.
 - Many domain-specific packages are built on top of NumPy and can offer similar performance boosts.
-- Pandas' data tables store columns as arrays, therefore operations applied to columns can take advantage of NumPy’s vectorisation.
+- Pandas' data tables store columns as arrays, therefore operations applied to columns can take advantage of NumPy's vectorisation.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::

--- a/episodes/optimisation-numpy.md
+++ b/episodes/optimisation-numpy.md
@@ -30,7 +30,13 @@ Packages like NumPy and Pandas work similarly: They have been written in compile
 
 It adds restriction via it's own [basic numeric types](https://numpy.org/doc/stable/user/basics.types.html), and static arrays to enable even greater performance than that of core Python. However if these restrictions are ignored, the performance can become significantly worse.
 
-### Arrays
+<!--
+TODO: It might be nice to use the figure from https://jakevdp.github.io/blog/2014/05/09/why-python-is-slow/#3.-Python's-object-model-can-lead-to-inefficient-memory-access here for illustration?
+
+![Illustration of a NumPy array and a Python list.](episodes/fig/numpyarray_vs_pylist.png){alt="A diagram illustrating the difference between a NumPy array and a Python list. The NumPy array is a raw block of memory containing numerical values. A Python list contains a header with metadata and multiple items, each of which is a reference to another Python object with its own header and value."}
+-->
+
+### NumPy arrays and Python lists live in two separate worlds
 
 NumPy's arrays (not to be confused with the core Python `array` package) are static arrays. Unlike core Python's lists, they do not dynamically resize. Therefore if you wish to append to a NumPy array, you must call `resize()` first. If you treat this like `append()` for a Python list, resizing for each individual append you will be performing significantly more copies and memory allocations than a Python list.
 
@@ -58,7 +64,7 @@ print(f"list_append: {timeit(list_append, number=repeats):.2f}ms")
 print(f"array_resize: {timeit(array_resize, number=repeats):.2f}ms")
 ```
 
-Resizing a NumPy array is 5.2x slower than a list, probably 10x slower than list comprehension.
+For Python lists, we’ve seen earlier that list comprehensions are more efficient, so we prefer to avoid using a large number of `append` operations if possible. Similarly, we should try to avoid resizing NumPy arrays, where the overhead is even higher (5.2x slower than a list, probably 10x slower than list comprehension).
 
 ```output
 list_append: 3.50ms
@@ -190,14 +196,14 @@ However, using NumPy broadcasting we can apply the addition to 1, 10 or 100 elem
 Earlier in this episode it was demonstrated that using core Python methods over a list, will outperform a loop performing the same calculation faster. The below example takes this a step further by demonstrating the calculation of dot product.
 
 <!-- Inspired by High Performance Python Chapter 6 example 
-Added python sum array, skipped a couple of others--> 
+Added Python sum array, skipped a couple of others--> 
 ```python
 from timeit import timeit
 
-N = 1000000  # Number of elements in list
+N = 1_000_000  # Number of elements in list
 
 gen_list = f"ls = list(range({N}))"
-gen_array = f"import numpy;ar = numpy.arange({N}, dtype=numpy.int64)"
+gen_array = f"import numpy; ar = numpy.arange({N}, dtype=numpy.int64)"
 
 py_sum_ls = "sum([i*i for i in ls])"
 py_sum_ar = "sum(ar*ar)"
@@ -232,7 +238,7 @@ NumPy can sometimes take advantage of auto parallelisation, particularly on HPC 
 
 A small number of functions are backed by BLAS and LAPACK, enabling even greater speedup.
 
-The [supported functions](https://numpy.org/doc/stable/reference/routines.linalg.html) mostly correspond to linear algebra operations.
+The [supported functions](https://numpy.org/doc/stable/reference/routines.linalg.html) mostly correspond to linear algebra operations like `numpy.dot()`.
 
 The auto-parallelisation of these functions is hardware dependant, so you won't always automatically get the additional benefit of parallelisation.
 However, HPC systems should be primed to take advantage, so try increasing the number of cores you request when submitting your jobs and see if it improves the performance.
@@ -244,7 +250,7 @@ However, HPC systems should be primed to take advantage, so try increasing the n
 ### `vectorize()`
 
 Python's `map()` was introduced earlier, for applying a function to all elements within a list.
-NumPy provides `vectorize()` an equivalent for operating over it's arrays.
+NumPy provides `vectorize()` an equivalent for operating over its arrays.
 
 This doesn't actually make use of processor-level vectorisation, from the [documentation](https://numpy.org/doc/stable/reference/generated/numpy.vectorize.html):
 
@@ -367,7 +373,7 @@ Code diff: https://github.com/SNEWS2/snewpy/pull/310/commits/0320b384ff22233818d
 
 Similar to NumPy, Pandas enables greater performance than pure Python implementations when used correctly, however incorrect usage can actively harm performance.
 
-## Operating on Rows
+### Operating on Rows
 
 Pandas' methods by default operate on columns. Each column or series can be thought of as a NumPy array, highly suitable for vectorisation.
 
@@ -499,7 +505,7 @@ series: 237.25ms
 dictionary: 3.63ms
 ```
 
-## Filter Early
+### Filter Early
 
 If you can filter your rows before processing, rather than after, you may significantly reduce the amount of processing and memory used.
 
@@ -508,5 +514,6 @@ If you can filter your rows before processing, rather than after, you may signif
 - Python is an interpreted language, this adds an additional overhead at runtime to the execution of Python code. Many core Python and NumPy functions are implemented in faster C/C++, free from this overhead.
 - NumPy can take advantage of vectorisation to process arrays, which can greatly improve performance.
 - Many domain-specific packages are built on top of NumPy and can offer similar performance boosts.
+- Pandas' data tables store columns as arrays, therefore operations applied to columns can take advantage of NumPy’s vectorisation.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -33,6 +33,15 @@ pip install pytest snakeviz line_profiler[all] numpy pandas matplotlib
 
 To complete some of the exercises you will need to use a text-editor or Python IDE, so make sure you have your favourite available.
 
+:::::::::::::: instructor
+
+As the instructor, you should additionally install the `shapely` package, which you may need for a brief demo during the episode on scientific Python packages.
+
+```sh
+pip install shapely
+```
+
+:::::::::::::::::::::::::
 
 
 :::::::::::::::: spoiler


### PR DESCRIPTION
_Note: I’ve split my changes out into separate PRs as explained in #54. While most of these changes are independent of each other, this PR here depends on #54; please merge that PR first. To avoid confusion, I’m marking this as a draft for now._

This significantly updates the dedicated NumPy page that is the result of the restructuring in #54:
* add new content on array broadcasting
* add a simpler, more striking example for vectorisation
* mention wide range of other packages built on top of NumPy (not just Pandas)
* delete section on `numpy.vectorize()`, which has become confusing and misleading now that the content on broadcasting/vectorisation is expanded

----

One open issue is that I’m currently not quite happy with the callout on `numpy.random.choice()`:
* When calling this once, the few usec are completely negligible, so the readability of `random.choice()` is clearly preferable (as the text says).
* However, when calling that function N times, the text sounds to me like it assumes a for loop. In practice, it would be better to use `random.choice(ar, size=N)` to get a large number of random choices in one call; thanks to vectorisation, that will likely be much more efficient. However, it would not work with the first example in that callout.

I don’t think that is a significant issue; so I’d probably err on the side of leaving that as is for now. I can always make another PR if I find time to improve that paragraph.