### PR TITLE
Include Performant Python Patterns recording.

### DIFF
--- a/learners/ppp.md
+++ b/learners/ppp.md
@@ -2,9 +2,15 @@
 title: Performant Python Patterns (Talk)
 ---
 
-**Slides**
-
 The 25 minute talk, which introduces many of the Python patterns from the Optimisation section of the course, was first delivered at [RSECon24](https://rsecon24.society-rse.org/).
+
+The recording, slides and an accompanying Jupyter notebook are available below.
+
+**Recording**
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/JeAzyCzFr7U?si=DY4_D1jggIbWDpFp" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+**Slides**
 
 <iframe src="https://docs.google.com/presentation/d/1Rs-nZbcnK8i1MOp9IhCnIa5NKdZ_bSPUyMY4vaPjLLA/embed?start=false&loop=false&delayms=15000" frameborder="0" width="960" height="569" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
 


### PR DESCRIPTION
I spotted I hadn't updated this page to include the recording of the talk whilst explaining it to my SSI mentor.

Happy to remove this page from the incubator fork if you don't think it's appropriate.

*Tested building this locally to check the embed works. It does, however I think my local varnish install is broken as the broader style has missing elements across the site.*