### PR TITLE
do setup only once

### DIFF
--- a/episodes/optimisation-data-structures-algorithms.md
+++ b/episodes/optimisation-data-structures-algorithms.md
@@ -238,41 +238,36 @@ If you reduce the value of `repeats` it will run faster, how does changing the n
 import random
 from timeit import timeit
 
-def generateInputs(N = 25000):
-    random.seed(12)  # Ensure every list is the same 
-    return [random.randint(0,int(N/2)) for i in range(N)]
-    
+N = 25000  # Number of elements in the list
+random.seed(12)  # Ensure every list is the same 
+data = [random.randint(0, int(N/2)) for i in range(N)]
+
 def uniqueSet():
-    ls_in = generateInputs()
-    set_out = set(ls_in)
+    set_out = set(data)
     
 def uniqueSetAdd():
-    ls_in = generateInputs()
     set_out = set()
-    for i in ls_in:
+    for i in data:
         set_out.add(i)
     
 def uniqueList():
-    ls_in = generateInputs()
     ls_out = []
-    for i in ls_in:
+    for i in data:
         if not i in ls_out:
             ls_out.append(i)
 
 def uniqueListSort():
-    ls_in = generateInputs()
-    ls_in.sort()
+    ls_in = sorted(data)
     ls_out = [ls_in[0]]
     for i in ls_in:
         if ls_out[-1] != i:
             ls_out.append(i)
-            
+
 repeats = 1000
-gen_time = timeit(generateInputs, number=repeats)
-print(f"uniqueSet: {timeit(uniqueSet, number=repeats)-gen_time:.2f}ms")
-print(f"uniqueSetAdd: {timeit(uniqueSetAdd, number=repeats)-gen_time:.2f}ms")
-print(f"uniqueList: {timeit(uniqueList, number=repeats)-gen_time:.2f}ms")
-print(f"uniqueListSort: {timeit(uniqueListSort, number=repeats)-gen_time:.2f}ms")
+print(f"uniqueSet: {timeit(uniqueSet, number=repeats):.2f}ms")
+print(f"uniqueSetAdd: {timeit(uniqueSetAdd, number=repeats):.2f}ms")
+print(f"uniqueList: {timeit(uniqueList, number=repeats):.2f}ms")
+print(f"uniqueListSort: {timeit(uniqueListSort, number=repeats):.2f}ms")
 ```
 
 :::::::::::::::::::::::: hint
@@ -325,41 +320,34 @@ from bisect import bisect_left
 N = 25000  # Number of elements in list
 M = 2  # N*M == Range over which the elements span
 
-def generateInputs():
-    random.seed(12)  # Ensure every list is the same
-    st = set([random.randint(0, int(N*M)) for i in range(N)])
-    ls = list(st)
-    ls.sort()  # Sort required for binary
-    return st, ls  # Return both set and list
+random.seed(12)  # Ensure every list is the same
+st = set([random.randint(0, int(N*M)) for i in range(N)])
+ls = list(st)
+ls.sort()  # Sort required for binary search
     
 def search_set():
-    st, _ = generateInputs()
     j = 0
     for i in range(0, int(N*M), M):
         if i in st:
             j += 1
     
 def linear_search_list():
-    _, ls = generateInputs()
     j = 0
     for i in range(0, int(N*M), M):
         if i in ls:
             j += 1
     
 def binary_search_list():
-    _, ls = generateInputs()
     j = 0
     for i in range(0, int(N*M), M):
         k = bisect_left(ls, i)
         if k != len(ls) and ls[k] == i:
             j += 1
 
-            
 repeats = 1000
-gen_time = timeit(generateInputs, number=repeats)
-print(f"search_set: {timeit(search_set, number=repeats)-gen_time:.2f}ms")
-print(f"linear_search_list: {timeit(linear_search_list, number=repeats)-gen_time:.2f}ms")
-print(f"binary_search_list: {timeit(binary_search_list, number=repeats)-gen_time:.2f}ms")
+print(f"search_set: {timeit(search_set, number=repeats):.2f}ms")
+print(f"linear_search_list: {timeit(linear_search_list, number=repeats):.2f}ms")
+print(f"binary_search_list: {timeit(binary_search_list, number=repeats):.2f}ms")
 ```
 
 Searching the set is fastest performing 25,000 searches in 0.04ms.

--- a/episodes/optimisation-using-python.md
+++ b/episodes/optimisation-using-python.md
@@ -111,16 +111,14 @@ The function `manualSearch()` manually iterates through the list (`ls`) and chec
 
 ```python
 import random
+from timeit import timeit
 
 N = 2500  # Number of elements in list
 M = 2  # N*M == Range over which the elements span
-
-def generateInputs():
-    random.seed(12)  # Ensure every list is the same
-    return [random.randint(0, int(N*M)) for i in range(N)]
+random.seed(12)  # Ensure every list is the same
+ls = [random.randint(0, int(N*M)) for i in range(N)]
     
 def manualSearch():
-    ls = generateInputs()
     ct = 0
     for i in range(0, int(N*M), M):
         for j in range(0, len(ls)):
@@ -129,16 +127,14 @@ def manualSearch():
                 break
 
 def operatorSearch():
-    ls = generateInputs()
     ct = 0
     for i in range(0, int(N*M), M):
         if i in ls:
             ct += 1
 
 repeats = 1000
-gen_time = timeit(generateInputs, number=repeats)
-print(f"manualSearch: {timeit(manualSearch, number=repeats)-gen_time:.2f}ms")
-print(f"operatorSearch: {timeit(operatorSearch, number=repeats)-gen_time:.2f}ms")
+print(f"manualSearch: {timeit(manualSearch, number=repeats):.2f}ms")
+print(f"operatorSearch: {timeit(operatorSearch, number=repeats):.2f}ms")
 ```
 
 This results in the manual Python implementation being 5x slower, doing the exact same operation!


### PR DESCRIPTION
Previously, some code examples would run the setup step as part of the timed function, repeating it thousands of times. In particular, for the two examples in `episodes/optimisation-data-structures-algorithms.md` the setup step took about 6 ms (an order of magnitude longer than the faster methods).
Running the setup just once shaves about 20 s of the runtime of these examples. It also makes the timing cleaner (because it is no longer necessary to substract the setup time) and potentially more reliable.

There are two open questions before we merge this:
- [ ] For the search example, I’m getting `search_set: 0.6 ms`, `linear_search_list: 1500 ms` and `binary_search_list: 3.36ms`. The latter are about 1.5× faster than described in the text, which is reasonable; but the first one is an order of magnitude _slower_. Could you double check, please? (I’m wondering if substracting the setup time might have affected the result there …)
- [ ] The technical appendix on bytecode uses the `manualSearch` and `operatorSearch` examples, so should probably be updated alongside these changes. However, I noticed that Python 3.13 produces a few different bytecodes, even for the code that remained unchanged. I’m wondering how we should deal with this; especially w/r/t #75.
